### PR TITLE
Further improvements to installation instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,8 +29,16 @@ pip install .[test]
 ```
 pytest
 ```
-## Usage
+7. Once you've done your work with `pyCascadia`, you may want to deactivate the environment and return to your base python environment. You can do so by running:
+```
+conda deactivate
+```
 
+## Usage
+Before using any part of `pyCascadia`, make sure you've got its conda environment activated (change "cascadia" to the name of your environment if you've named it differently when following the installation instructions).
+```
+conda activate cascadia
+```
 ### Remove restore
 
 `pyCascadia` provides the remove restore algorithm as a command line tool called `remove-restore`, e.g.

--- a/README.md
+++ b/README.md
@@ -37,7 +37,12 @@ pytest
 ```
 remove-restore --base gebco_base_grid.nc higher_res_grid.tiff --output merged_grid.nc
 ```
-Input base and source grids are accepted in both GeoTiff or NetCDF formats. For more details on input arguments of `remove-restore`, run
+Input base and source grids are accepted in both GeoTiff or NetCDF formats. It is possible to provide more than one source grid, e.g with three source grids one would call:
+```
+remove-restore --base gebco_base_grid.nc higher_res_grid1.tiff higher_res_grid2.tiff higher_res_grid3 --output merged_grid.nc
+```
+
+For more details on input arguments of `remove-restore`, run
 ```
 remove-restore -h
 ```

--- a/README.md
+++ b/README.md
@@ -42,7 +42,7 @@ Input base and source grids are accepted in both GeoTiff or NetCDF formats. It i
 remove-restore --base gebco_base_grid.nc higher_res_grid1.tiff higher_res_grid2.tiff higher_res_grid3 --output merged_grid.nc
 ```
 
-For more details on input arguments of `remove-restore`, run
+For more details on these and other input arguments of `remove-restore`, run
 ```
 remove-restore -h
 ```

--- a/README.md
+++ b/README.md
@@ -55,7 +55,7 @@ The scripts `close_boundary.py` and `generate_contour.sh` provide a way to close
 
 Generate a new netCDF file with any land-boundaries set to $z=0$:
 
-`pipenv run python close_boundary.py --input <input.nc> --output <output.nc>`
+`python close_boundary.py --input <input.nc> --output <output.nc>`
 
 Generate closed contours:
 


### PR DESCRIPTION
Addresses the comments about installation instructions given by @Devaraj-G via email (Thank you).

Namely:

> [3] remove-restore -h gives
> positional arguments:
>   filenames             sources to combine with the base grid
> 
> It would be helpful to update the usage showing a case for multiple input files, e.g.
> remove-restore --base gebco_base_grid.nc higher_res_grid1.tiff higher_res_grid2.tiff ... --output merged_grid.nc
> 
> [4] Running close_boundary.py:
> pipenv run python ./scripts/close_boundary.py --input gdal_translate_OK24.xyz.nc --output gdal_translate_OK24.xyz.shp gives
> Traceback (most recent call last): 
>   File "/home/devaraj/Desktop/Work/Data/pyCascadia/./scripts/close_boundary.py", line 3, in <module>
>     from pycascadia.loaders import load_source
> ModuleNotFoundError: No module named 'pycascadia'
> 