### PR TITLE
Enhance boundary closure

### DIFF
--- a/pycascadia/remove_restore.py
+++ b/pycascadia/remove_restore.py
@@ -85,10 +85,10 @@ def main():
     parser.add_argument('--diff_threshold', default=0.0, help='value above which differences will be added to the base grid')
     parser.add_argument('--plot', action='store_true', help='plot final output before saving')
     parser.add_argument('--output', required=True, help='filename of final output')
-    parser.add_argument('--region_of_interest', required=False, nargs=4, type=float,
-                        help='output region in order <xmin> <xmax> <ymin> <ymax>. Defaults to the extent of the base grid.')
     parser.add_argument('--window_width', required=False, type=float,
                         help='Enable windowing of update grid and specify width of window in degrees')
+    parser.add_argument('--region_of_interest', metavar=('xmin', 'xmax', 'ymin', 'ymax'), required=False, nargs=4, type=float,
+                        help='output region. Defaults to the extent of the base grid.')
     args = parser.parse_args()
 
     filenames = args.filenames

--- a/scripts/close_boundary.py
+++ b/scripts/close_boundary.py
@@ -1,6 +1,7 @@
 #!/usr/bin/env python3
 
 from pycascadia.loaders import load_source
+from pygmt import grdcut
 import matplotlib.pyplot as plt
 import argparse
 
@@ -19,10 +20,15 @@ def main():
     parser.add_argument('--value', type=float, default=0.0, help='value to replace boundary with')
     parser.add_argument('--offset', action='store_true', default=False, help='use one index from true boundary as boundary')
     parser.add_argument('--plot', action='store_true', default=False, help='plot final grid before saving')
+    parser.add_argument('--region', required=False, metavar=('xmin', 'xmax', 'ymin', 'ymax'), nargs=4, type=float,
+                        help='output region. Defaults to the extent of the input grid.')
     args = parser.parse_args()
 
     in_fname = args.input
     input_grid, _, _  = load_source(in_fname, plot=False)
+
+    if args.region:
+        input_grid = grdcut(input_grid, region=args.region)
 
     if args.offset:
         replace_land_with_zeros(input_grid[0,:], input_grid[1,:], value=args.value)

--- a/scripts/close_boundary.py
+++ b/scripts/close_boundary.py
@@ -1,6 +1,7 @@
 #!/usr/bin/env python3
 
 from pycascadia.loaders import load_source
+import matplotlib.pyplot as plt
 import argparse
 
 def replace_land_with_zeros(arr, test_arr=None):
@@ -16,6 +17,7 @@ def main():
     parser.add_argument('--input', required=True, help='input file')
     parser.add_argument('--output', required=True, help='output file')
     parser.add_argument('--offset', action='store_true', default=False, help='use one index from true boundary as boundary')
+    parser.add_argument('--plot', action='store_true', default=False, help='plot final grid before saving')
     args = parser.parse_args()
 
     in_fname = args.input
@@ -31,6 +33,20 @@ def main():
         replace_land_with_zeros(input_grid[-1,:])
         replace_land_with_zeros(input_grid[:,0])
         replace_land_with_zeros(input_grid[:,-1])
+
+    if args.plot:
+        # Plot bath & contour on top
+        input_grid.plot()
+        plt.contour(input_grid.x, input_grid.y, input_grid.values, levels=[0.0])
+
+        # Increase view of region to display closed contours
+        BORDER_SCALE = 0.1
+        x_diff = input_grid.x[-1] - input_grid.x[0]
+        y_diff = input_grid.y[-1] - input_grid.y[0]
+        plt.xlim(input_grid.x[0]-BORDER_SCALE*x_diff, input_grid.x[-1]+BORDER_SCALE*x_diff)
+        plt.ylim(input_grid.y[0]-BORDER_SCALE*y_diff, input_grid.y[-1]+BORDER_SCALE*y_diff)
+
+        plt.show()
 
     input_grid.to_netcdf(args.output)
 

--- a/scripts/close_boundary.py
+++ b/scripts/close_boundary.py
@@ -4,11 +4,11 @@ from pycascadia.loaders import load_source
 import matplotlib.pyplot as plt
 import argparse
 
-def replace_land_with_zeros(arr, test_arr=None):
+def replace_land_with_zeros(arr, test_arr=None, value=0.0):
     if test_arr is None:
         test_arr = arr
 
-    arr[test_arr>0] = 0
+    arr[test_arr>value] = value
 
 
 def main():
@@ -16,6 +16,7 @@ def main():
     parser = argparse.ArgumentParser(description='Add halo surrounding given netcdf file')
     parser.add_argument('--input', required=True, help='input file')
     parser.add_argument('--output', required=True, help='output file')
+    parser.add_argument('--value', type=float, default=0.0, help='value to replace boundary with')
     parser.add_argument('--offset', action='store_true', default=False, help='use one index from true boundary as boundary')
     parser.add_argument('--plot', action='store_true', default=False, help='plot final grid before saving')
     args = parser.parse_args()
@@ -24,20 +25,20 @@ def main():
     input_grid, _, _  = load_source(in_fname, plot=False)
 
     if args.offset:
-        replace_land_with_zeros(input_grid[0,:], input_grid[1,:])
-        replace_land_with_zeros(input_grid[-1,:], input_grid[-2,:])
-        replace_land_with_zeros(input_grid[:,0], input_grid[:,1])
-        replace_land_with_zeros(input_grid[:,-1], input_grid[:,-2])
+        replace_land_with_zeros(input_grid[0,:], input_grid[1,:], value=args.value)
+        replace_land_with_zeros(input_grid[-1,:], input_grid[-2,:], value=args.value)
+        replace_land_with_zeros(input_grid[:,0], input_grid[:,1], value=args.value)
+        replace_land_with_zeros(input_grid[:,-1], input_grid[:,-2], value=args.value)
     else:
-        replace_land_with_zeros(input_grid[0,:])
-        replace_land_with_zeros(input_grid[-1,:])
-        replace_land_with_zeros(input_grid[:,0])
-        replace_land_with_zeros(input_grid[:,-1])
+        replace_land_with_zeros(input_grid[0,:], value=args.value)
+        replace_land_with_zeros(input_grid[-1,:], value=args.value)
+        replace_land_with_zeros(input_grid[:,0], value=args.value)
+        replace_land_with_zeros(input_grid[:,-1], value=args.value)
 
     if args.plot:
         # Plot bath & contour on top
         input_grid.plot()
-        plt.contour(input_grid.x, input_grid.y, input_grid.values, levels=[0.0])
+        plt.contour(input_grid.x, input_grid.y, input_grid.values, levels=[args.value])
 
         # Increase view of region to display closed contours
         BORDER_SCALE = 0.1

--- a/scripts/close_boundary.py
+++ b/scripts/close_boundary.py
@@ -5,7 +5,7 @@ from pygmt import grdcut
 import matplotlib.pyplot as plt
 import argparse
 
-def replace_land_with_zeros(arr, test_arr=None, value=0.0):
+def clip_to_value(arr, test_arr=None, value=0.0):
     if test_arr is None:
         test_arr = arr
 


### PR DESCRIPTION
This PR implements a number of features requested by @Devaraj-G:

- The level of the contour can now be set by the user (previously this was hard-coded to zero)
- What is considered a boundary (against which the contour is closed) can be changed by supplying the `--region` flag
- A plot of the predicted contours can be made for inspection

There is also a minor improvement to the remove-restore command line help, which presents the user with useful metadata for the region flag, instead of repeating REGION.