### PR TITLE
Add level parameter to GRASS contour extraction tool

### DIFF
--- a/scripts/generate_contour.sh
+++ b/scripts/generate_contour.sh
@@ -4,9 +4,10 @@ export GRASS_MESSAGE_FORMAT=plain
 
 input_fname=$1
 output_fname=$2
+level=$3
 
 r.in.gdal input=NETCDF:"$input_fname" output=elevation -o --overwrite
-r.contour in=elevation out=contours levels=0 cut=200 --overwrite
+r.contour in=elevation out=contours levels=$level cut=200 --overwrite
 v.out.ogr format=ESRI_Shapefile input=contours output=$output_fname --overwrite
 
 # For plotting


### PR DESCRIPTION
This PR adds a `level` parameter to the GRASS contour extraction script, allowing non-zero contours to be extracted.

WARNING - this is untested as of 10AM 17/06/2021