### PR TITLE
Hotfix/allow zero fnamses args

### DIFF
--- a/pycascadia/remove_restore.py
+++ b/pycascadia/remove_restore.py
@@ -84,7 +84,7 @@ def load_base_grid(fname, region=None, spacing=None):
 def main():
     # Handle arguments
     parser = argparse.ArgumentParser(description='Combine multiple bathymmetry sources into a single grid')
-    parser.add_argument('filenames', nargs='+', help='sources to combine with the base grid')
+    parser.add_argument('filenames', nargs='*', help='sources to combine with the base grid')
     parser.add_argument('--base', required=True, help='base grid')
     parser.add_argument('--input_txt', help='text file containing list of input grids')
     parser.add_argument('--spacing', type=float, help='output grid spacing')

--- a/pycascadia/remove_restore.py
+++ b/pycascadia/remove_restore.py
@@ -104,6 +104,8 @@ def main():
     # Add filenames from command line
     filenames += args.filenames
 
+    assert filenames != [], "No filenames given"
+
     base_fname = args.base
     diff_threshold = args.diff_threshold
     output_fname = args.output


### PR DESCRIPTION
*gollum*   **gollum**

more than one filenamses not required on command line now that remove-restore can take a file containing filenames. This PR allows zero filenames to be given on the command line. Ensuring there is more than one filename is left to an assertion.