### PR TITLE
Update minimum Python version in accordance with `xarray`

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -16,7 +16,7 @@ jobs:
           - ubuntu-latest
           - macos-latest
           - windows-latest
-        python: [3.6, 3.9]
+        python: [3.7, 3.9]
     steps:
       - uses: actions/checkout@v2
 

--- a/environment.yml
+++ b/environment.yml
@@ -4,6 +4,7 @@ channels:
     - defaults
 dependencies:
     # Required dependencies
+    - python>=3.7
     - pip
     - pygmt>=0.3.1
     - gdal


### PR DESCRIPTION
We need Python 3.7+ for `pyCascadia` to [work with latest `xarray` ](https://xarray.pydata.org/en/stable/getting-started-guide/installing.html?highlight=python%20versions#minimum-dependency-versions)(i.e., currently, `xarray 0.19`).

This PR
- ensures the CI is run with Python 3.7+
- ensures the conda environment is created with Python 3.7+

Addresses #68 .