### PR TITLE
Bugfix/increment mismatch

### DIFF
--- a/pycascadia/grid.py
+++ b/pycascadia/grid.py
@@ -61,6 +61,10 @@ class Grid:
     def resample(self, spacing: float) -> None:
         """
         Resamples the loaded grid using gdal's grdsample.
+        
+        Resampled grid may cover slightly expanded region (to East and North).
+        This is in order to guarantee the specified spacing.
+        See gmt grdsample `-I<increment>+e` flag for details.
 
         Args:
             spacing: Grid spacing of resampled grid.

--- a/pycascadia/grid.py
+++ b/pycascadia/grid.py
@@ -73,7 +73,7 @@ class Grid:
         self.save_grid(in_fname)
         out_fname = "resampled.nc"
         os.system(
-            f"gmt grdsample {in_fname} -G{out_fname} -R{region_to_str(self.region)} -I{spacing} -V"
+            f"gmt grdsample {in_fname} -G{out_fname} -R{region_to_str(self.region)} -I{spacing}+e -V"
         )
         self.load(out_fname)
         os.remove(in_fname)


### PR DESCRIPTION
Previously, the `grid.resample` function would not guarantee that the resampled grid had the exact user-specified spacing. This is because `gmt grdsample` would by default guarantee the specified region (and slightly adapt the spacing accordingly). This caused `pyCascadia` problems down the line, specifically when using interpolation to calculate the difference grid, which relies on knowing the spacing.

An alternative solution might be to store the spacing returned by `grdsample` in our grid class, and use that going forward. I will ask @dimitrasal for preferences.
