### PR TITLE
Get PyCascadia ready for publishing on PyPi

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -4,7 +4,7 @@ This document details the contribution guidelines and procedures for pyCascadia.
 
 ## Uploading to PyPi
 
-Uploading the latest version of cascadia to PyPi is currently done manually via the following steps. This must be done by an employee of UCL's research software development group.
+Uploading the latest version of `pyCascadia` to PyPi is currently done manually via the following steps. This must be done by an employee of UCL's research software development group.
 
 1. Create the package:
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,25 @@
+# Contributing (WIP)
+
+This document details the contribution guidelines and procedures for pyCascadia.
+
+## Uploading to PyPi
+
+Uploading the latest version of cascadia to PyPi is currently done manually via the following steps. This must be done by an employee of UCL's research software development group.
+
+1. Create the package:
+
+```
+python setup.py sdist bdist_wheel
+```
+
+2. Check with `twine`:
+
+```
+twine check dist/*
+```
+
+3. If twine reports no errors or warnings, upload to PyPi (optionally uploading to testpypi first)
+
+```
+python3 -m twine upload [--repository testpypi] dist/*
+```

--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,0 +1,1 @@
+include test_data/*

--- a/README.md
+++ b/README.md
@@ -31,9 +31,9 @@ conda deactivate
 ```
 
 ## Usage
-Before using any part of `pyCascadia`, make sure you've got its conda environment activated (change "cascadia" to the name of your environment if you've named it differently when following the installation instructions).
+Before using any part of `pyCascadia`, make sure you've got its conda environment activated (change `pycascadia` to the name of your environment if you've named it differently when following the installation instructions).
 ```
-conda activate cascadia
+conda activate pycascadia
 ```
 ### Remove restore
 

--- a/README.md
+++ b/README.md
@@ -1,15 +1,19 @@
 # pyCascadia
 Implementation of GEBCO cookbook remove-restore and other cleaning of topography/bathymetry. Uses `pyGMT`.
 
+## Dependencies
+
+The non-python dependencies are:
+
+- gdal
+- GMT
+
 ## Installation
 Some dependencies of the package are a bit fiddly to install, especially on Windows.
-We recommend to use a conda environment, and install the more difficult dependencies through `conda-forge`,
+We recommend using a conda environment, and installing the more difficult dependencies through `conda-forge`,
 by running the commands below in sequence:
-1. Clone this GitHub repository.
-```
-git clone https://github.com/UCL/pyCascadia.git
-```
-2. The proceeding steps assume your current working directory is your local copy of the repository. A mixture of conda and pip is used to install the dependencies (due to the complex dependencies gdal and rasterio). The conda dependencies are listed in [environment.yml](https://github.com/UCL/pyCascadia/blob/main/environment.yml) which will be automatically used by conda when creating a new environment:
+
+1. The proceeding steps assume your current working directory is your local copy of the repository. A mixture of conda and pip is used to install the dependencies (due to the complex dependencies gdal and rasterio). The conda dependencies are listed in [environment.yml](https://github.com/UCL/pyCascadia/blob/main/environment.yml) which will be automatically used by conda when creating a new environment:
 ```
 conda env create
 ```
@@ -19,13 +23,9 @@ conda activate pycascadia
 ```
 4. Install `pyCascadia`. This will also automatically install the remaining dependencies (a list of which can be found in [setup.cfg](https://github.com/UCL/pyCascadia/blob/main/setup.cfg)).
 ```
-pip install .
+pip install pycascadia
 ```
-5. Check the installation worked by running the unit tests:
-```
-pytest
-```
-6. Once you've done your work with `pyCascadia`, you may want to deactivate the environment and return to your base python environment. You can do so by running:
+5. Once you've done your work with `pyCascadia`, you may want to deactivate the environment and return to your base python environment. You can do so by running:
 ```
 conda deactivate
 ```

--- a/README.md
+++ b/README.md
@@ -19,7 +19,7 @@ conda activate pycascadia
 ```
 4. Install `pyCascadia`. This will also automatically install the remaining dependencies (a list of which can be found in [setup.cfg](https://github.com/UCL/pyCascadia/blob/main/setup.cfg)).
 ```
-pip install .[test]
+pip install .
 ```
 5. Check the installation worked by running the unit tests:
 ```

--- a/environment.yml
+++ b/environment.yml
@@ -9,4 +9,3 @@ dependencies:
     - pygmt>=0.3.1
     - gdal
     - rasterio
-    - pytest

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,5 +1,5 @@
 [bumpversion]
-current_version = 1.0.2
+current_version = 1.0.3
 commit = True
 tag = True
 

--- a/setup.cfg
+++ b/setup.cfg
@@ -37,6 +37,7 @@ dev =
     pdoc3
     black
     flake8
+    twine
 
 [options.entry_points]
 console_scripts =

--- a/setup.cfg
+++ b/setup.cfg
@@ -20,8 +20,12 @@ scripts =
   scripts/delete-variable
 
 [options.extras_require]
-test =
+dev =
     pytest
+    bump2version
+    pdoc3
+    black
+    flake8
 
 [options.entry_points]
 console_scripts =

--- a/setup.cfg
+++ b/setup.cfg
@@ -53,4 +53,4 @@ current_version = 1.0.0
 commit = True
 tag = True
 
-[bumpversion:file:setup.py]
+[bumpversion:file:setup.cfg]

--- a/setup.cfg
+++ b/setup.cfg
@@ -2,9 +2,14 @@
 name=pyCascadia
 version=1.0.0
 #license=MIT
-author=Jamie Quinn; Alessandro Felder
-author_email=
+author =
+    Jamie Quinn
+    Alessandro Felder
+author_email = rc-softdev@ucl.ac.uk
 url = https://github.com/UCL/pyCascadia
+classifiers=
+    Programming Language :: Python :: 3
+    Programming Language :: Python :: 3.7
 
 [options]
 packages = pycascadia

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,11 +1,11 @@
 [bumpversion]
-current_version = 1.0.1
+current_version = 1.0.2
 commit = True
 tag = True
 
 [metadata]
 name = pyCascadia
-version = 1.0.1
+version = 1.0.2
 license = MPL
 author = Alessandro Felder; Jamie Quinn
 author_email = rc-softdev@ucl.ac.uk

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,7 +1,7 @@
 [metadata]
 name=pyCascadia
 version=1.0.0
-#license=MIT
+license=MPL
 author =
     Jamie Quinn
     Alessandro Felder
@@ -10,6 +10,7 @@ url = https://github.com/UCL/pyCascadia
 classifiers=
     Programming Language :: Python :: 3
     Programming Language :: Python :: 3.7
+    License :: OSI Approved :: Mozilla Public License 2.0 (MPL 2.0)
     Intended Audience :: Science/Research
     Natural Language :: English
     Topic :: Scientific/Engineering :: GIS

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,6 +1,6 @@
 [metadata]
 name=pyCascadia
-version=0.1
+version=1.0.0
 #license=MIT
 author=Jamie Quinn; Alessandro Felder
 author_email=
@@ -37,3 +37,10 @@ ignore = E203, E266, E501, W503, F403, F401
 max-line-length = 79
 max-complexity = 18
 select = B,C,E,F,W,T4,B9
+
+[bumpversion]
+current_version = 1.0.0
+commit = True
+tag = True
+
+[bumpversion:file:setup.py]

--- a/setup.cfg
+++ b/setup.cfg
@@ -15,6 +15,7 @@ classifiers=
     Topic :: Scientific/Engineering :: GIS
     Topic :: Scientific/Engineering :: Hydrology
     Topic :: Scientific/Engineering :: Oceanography
+    Operating System :: OS Independent
 
 [options]
 packages = pycascadia

--- a/setup.cfg
+++ b/setup.cfg
@@ -5,7 +5,6 @@ tag = True
 
 [metadata]
 name = pyCascadia
-version = 1.0.2
 license = MPL
 author = Alessandro Felder; Jamie Quinn
 author_email = rc-softdev@ucl.ac.uk
@@ -53,4 +52,4 @@ max-line-length = 79
 max-complexity = 18
 select = B,C,E,F,W,T4,B9
 
-[bumpversion:file:setup.cfg]
+[bumpversion:file:setup.py]

--- a/setup.cfg
+++ b/setup.cfg
@@ -10,6 +10,11 @@ url = https://github.com/UCL/pyCascadia
 classifiers=
     Programming Language :: Python :: 3
     Programming Language :: Python :: 3.7
+    Intended Audience :: Science/Research
+    Natural Language :: English
+    Topic :: Scientific/Engineering :: GIS
+    Topic :: Scientific/Engineering :: Hydrology
+    Topic :: Scientific/Engineering :: Oceanography
 
 [options]
 packages = pycascadia

--- a/setup.cfg
+++ b/setup.cfg
@@ -2,11 +2,9 @@
 name=pyCascadia
 version=1.0.0
 license=MPL
-author =
-    Jamie Quinn
-    Alessandro Felder
-author_email = rc-softdev@ucl.ac.uk
-url = https://github.com/UCL/pyCascadia
+author=Alessandro Felder; Jamie Quinn
+author_email=rc-softdev@ucl.ac.uk
+url=https://github.com/UCL/pyCascadia
 classifiers=
     Programming Language :: Python :: 3
     Programming Language :: Python :: 3.7

--- a/setup.cfg
+++ b/setup.cfg
@@ -8,7 +8,8 @@ url = https://github.com/UCL/pyCascadia
 
 [options]
 packages = pycascadia
-python_requires = >=3.6
+python_requires = >=3.7
+include_package_data = True
 install_requires =
   pygmt
   matplotlib

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,45 +1,50 @@
+[bumpversion]
+current_version = 1.0.1
+commit = True
+tag = True
+
 [metadata]
-name=pyCascadia
-version=1.0.0
-license=MPL
-author=Alessandro Felder; Jamie Quinn
-author_email=rc-softdev@ucl.ac.uk
-url=https://github.com/UCL/pyCascadia
-classifiers=
-    Programming Language :: Python :: 3
-    Programming Language :: Python :: 3.7
-    License :: OSI Approved :: Mozilla Public License 2.0 (MPL 2.0)
-    Intended Audience :: Science/Research
-    Natural Language :: English
-    Topic :: Scientific/Engineering :: GIS
-    Topic :: Scientific/Engineering :: Hydrology
-    Operating System :: OS Independent
+name = pyCascadia
+version = 1.0.1
+license = MPL
+author = Alessandro Felder; Jamie Quinn
+author_email = rc-softdev@ucl.ac.uk
+url = https://github.com/UCL/pyCascadia
+classifiers = 
+	Programming Language :: Python :: 3
+	Programming Language :: Python :: 3.7
+	License :: OSI Approved :: Mozilla Public License 2.0 (MPL 2.0)
+	Intended Audience :: Science/Research
+	Natural Language :: English
+	Topic :: Scientific/Engineering :: GIS
+	Topic :: Scientific/Engineering :: Hydrology
+	Operating System :: OS Independent
 
 [options]
 packages = pycascadia
 python_requires = >=3.7
 include_package_data = True
-install_requires =
-  pygmt >= 0.3.1
-  matplotlib
-  rasterio
-  xarray
-  pandas
-scripts =
-  scripts/delete-variable
+install_requires = 
+	pygmt >= 0.3.1
+	matplotlib
+	rasterio
+	xarray
+	pandas
+scripts = 
+	scripts/delete-variable
 
 [options.extras_require]
-dev =
-    pytest
-    bump2version
-    pdoc3
-    black
-    flake8
-    twine
+dev = 
+	pytest
+	bump2version
+	pdoc3
+	black
+	flake8
+	twine
 
 [options.entry_points]
-console_scripts =
-    remove-restore = pycascadia.remove_restore:main
+console_scripts = 
+	remove-restore = pycascadia.remove_restore:main
 
 [flake8]
 per-file-ignores = __init__.py:F401
@@ -47,10 +52,5 @@ ignore = E203, E266, E501, W503, F403, F401
 max-line-length = 79
 max-complexity = 18
 select = B,C,E,F,W,T4,B9
-
-[bumpversion]
-current_version = 1.0.0
-commit = True
-tag = True
 
 [bumpversion:file:setup.cfg]

--- a/setup.cfg
+++ b/setup.cfg
@@ -11,7 +11,7 @@ packages = pycascadia
 python_requires = >=3.7
 include_package_data = True
 install_requires =
-  pygmt
+  pygmt >= 0.3.1
   matplotlib
   rasterio
   xarray

--- a/setup.cfg
+++ b/setup.cfg
@@ -13,7 +13,6 @@ classifiers=
     Natural Language :: English
     Topic :: Scientific/Engineering :: GIS
     Topic :: Scientific/Engineering :: Hydrology
-    Topic :: Scientific/Engineering :: Oceanography
     Operating System :: OS Independent
 
 [options]

--- a/setup.cfg
+++ b/setup.cfg
@@ -15,6 +15,7 @@ install_requires =
   matplotlib
   rasterio
   xarray
+  pandas
 scripts =
   scripts/delete-variable
 

--- a/setup.py
+++ b/setup.py
@@ -7,5 +7,5 @@ with open('README.md', 'r', newline='', encoding='utf-8') as readme_file:
 setup(
     long_description = long_description,
     long_description_content_type = long_description_content_type,
-    version = 1.0.2,
+    version = 1.0.3,
 )

--- a/setup.py
+++ b/setup.py
@@ -7,4 +7,5 @@ with open('README.md', 'r', newline='', encoding='utf-8') as readme_file:
 setup(
     long_description = long_description,
     long_description_content_type = long_description_content_type,
+    version = 1.0.2,
 )

--- a/setup.py
+++ b/setup.py
@@ -7,5 +7,5 @@ with open('README.md', 'r', newline='', encoding='utf-8') as readme_file:
 setup(
     long_description = long_description,
     long_description_content_type = long_description_content_type,
-    version = 1.0.3,
+    version = "1.0.3",
 )

--- a/setup.py
+++ b/setup.py
@@ -1,3 +1,13 @@
+import pathlib
 from setuptools import setup
 
-setup()
+# The directory containing this file
+HERE = pathlib.Path(__file__).parent
+
+# The text of the README file
+README = (HERE / "README.md").read_text()
+
+setup(
+    long_description=README,
+    long_description_content_type="text/markdown",
+)

--- a/setup.py
+++ b/setup.py
@@ -1,13 +1,10 @@
-import pathlib
 from setuptools import setup
 
-# The directory containing this file
-HERE = pathlib.Path(__file__).parent
-
-# The text of the README file
-README = (HERE / "README.md").read_text()
+with open('README.md', 'r', newline='', encoding='utf-8') as readme_file:
+    long_description = readme_file.read()
+    long_description_content_type = 'text/markdown'
 
 setup(
-    long_description=README,
-    long_description_content_type="text/markdown",
+    long_description = long_description,
+    long_description_content_type = long_description_content_type,
 )


### PR DESCRIPTION
This PR gets pycascadia in a minimal viable state for publishing on PyPi. This is mostly tidying up `setup.cfg` and the readme. The package has already been published to [test pypi](https://test.pypi.org/project/pyCascadia/) and is rendering fine. Once this PR is approved the final step is to publish on the non-test pypi (details are in the new `CONTRIBUTING.md` document).

@alessandrofelder LMK what you think the first published version should be. From my playing about with bumpversion, it's currently sitting at v1.0.3, which I'm happy with tbh.